### PR TITLE
Don't index into unpredictably sized object

### DIFF
--- a/tests/testthat/testLifeExpectancy.R
+++ b/tests/testthat/testLifeExpectancy.R
@@ -310,10 +310,12 @@ test_that("LE - warnings are generated when invalid arguments are used",{
                "some groups have a total population of less than 5,000; outputs have been suppressed to NAs")
   expect_match(missing_warning,
                "some groups contain a different number of age bands than 20; life expectancy cannot be calculated for these\\. These groups will contain NAs\\.")
-  expect_match(wideci_warning[1],
-               "some age bands have more deaths than population; outputs have been suppressed to NAs")
-  expect_match(wideci_warning[2],
-               "some life expectancy values have a 95% confidence interval > 20 years; these values have been suppressed to NAs")
+  expect_match(wideci_warning,
+               "some age bands have more deaths than population; outputs have been suppressed to NAs",
+               all = FALSE)
+  expect_match(wideci_warning,
+               "some life expectancy values have a 95% confidence interval > 20 years; these values have been suppressed to NAs",
+               all = FALSE)
   expect_match(multi_warnings, "some age bands have negative deaths; outputs have been suppressed to NAs",
                all = FALSE)
   expect_match(multi_warnings, "some age bands have a zero or less population; outputs have been suppressed to NAs",


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, to be compatible with both dev and CRAN dplyr we need to work around broken tests of yours that were expecting something else.

Two of your tests were indexing into a warning object that expected it to be length 2, but since we throw a new warning here it is actually length 3. We can work around this easily by not indexing into the warning object at all and instead using `all = FALSE` in `expect_match()`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!